### PR TITLE
ACUS gamesubmission put back slot list

### DIFF
--- a/packages/amber/views/Games/GamesDialog.tsx
+++ b/packages/amber/views/Games/GamesDialog.tsx
@@ -372,35 +372,33 @@ export const GamesDialog: React.FC<GamesDialogProps> = ({ open, onClose, initial
               />
             </GridItem>
             {!slim && (
-              <>
-                <GridItem xs={12} md={12}>
-                  <p>
-                    You are welcome to start and end the game at any time (within reason), but if the game overlaps two
-                    slots, please enter two games and mark them as parts one and two.
-                  </p>
-                  {configuration.virtual && (
-                    <p>Please keep in mind that you might have players from multiple time zones in your game.</p>
-                  )}
-                  <SelectField
-                    name='estimatedLength'
-                    label='Estimated Length'
-                    margin='normal'
-                    fullWidth
-                    selectValues={estimatedLengthOptions}
-                  />
-                </GridItem>
-                <GridItem xs={12} md={12}>
-                  <SlotOptionsSelect
-                    name='slotPreference'
-                    label='Slot Preference'
-                    year={values.year}
-                    margin='normal'
-                    required
-                    fullWidth
-                  />
-                </GridItem>
-              </>
+              <GridItem xs={12} md={12}>
+                <p>
+                  You are welcome to start and end the game at any time (within reason), but if the game overlaps two
+                  slots, please enter two games and mark them as parts one and two.
+                </p>
+                {configuration.virtual && (
+                  <p>Please keep in mind that you might have players from multiple time zones in your game.</p>
+                )}
+                <SelectField
+                  name='estimatedLength'
+                  label='Estimated Length'
+                  margin='normal'
+                  fullWidth
+                  selectValues={estimatedLengthOptions}
+                />
+              </GridItem>
             )}
+            <GridItem xs={12} md={12}>
+              <SlotOptionsSelect
+                name='slotPreference'
+                label='Slot Preference'
+                year={values.year}
+                margin='normal'
+                required
+                fullWidth
+              />
+            </GridItem>
             {!configuration.startDates[values.year].virtual && (
               <>
                 <GridItem xs={12} md={12}>


### PR DESCRIPTION
Over simplified the game submission / edit form (GamesDialog.tsx) and when fixing a typo, cleaned it up to remove the leading text about the game starting any time and spanning multiple slots.

I removed too much: I removed the whole strip of leading text, the estimated length dropdown, and the dropdown with slots and "Any slot"

Resolves: #39