### PR TITLE
Add role that only can access reports

### DIFF
--- a/packages/amber/components/Auth/PermissionRules.ts
+++ b/packages/amber/components/Auth/PermissionRules.ts
@@ -20,6 +20,7 @@ export enum Roles {
   ROLE_ADMIN = 'ROLE_ADMIN',
   ROLE_GAME_ADMIN = 'ROLE_GAME_ADMIN',
   ROLE_USER = 'ROLE_USER',
+  ROLE_REPORTS = 'ROLE_REPORTS',
 }
 
 const rules: Rules = {
@@ -30,6 +31,9 @@ const rules: Rules = {
   },
   [Roles.ROLE_GAME_ADMIN]: {
     static: [Perms.FullGameBook, Perms.GameAdmin, Perms.Reports, Perms.IsLoggedIn],
+  },
+  [Roles.ROLE_REPORTS]: {
+    static: [Perms.Reports, Perms.IsLoggedIn],
   },
   [Roles.ROLE_USER]: {
     static: [Perms.IsLoggedIn],


### PR DESCRIPTION
Execute on database:

INSERT INTO role (id, authority) VALUES(5, 'ROLE_REPORTS');

This change allows assigning a role of ROLE_REPORTS to a user and they get the Reports link in the left bar and access to the download reports only.

N.B. I would remove Perms.Reports from Roles.ROLE_GAME_ADMIN and
     instead assign a user that needs both both the roles of
     ROLE_GAME_ADMIN and ROLE_REPORTS, but that may break ACNW.

Resolves: #43