### PR TITLE
Refactor Role/Permissions implementation

### DIFF
--- a/packages/amber/components/Auth/PermissionRules.ts
+++ b/packages/amber/components/Auth/PermissionRules.ts
@@ -1,43 +1,44 @@
-import { AtLeastOne } from 'ui'
+import { asEnumLike, AtLeastOne, keys } from 'ui'
 
-type Permissions = AtLeastOne<{
-  dynamic?: Record<string, unknown>
+export type PermissionDeclaration = AtLeastOne<{
+  dynamic?: Record<string, (data: any) => boolean>
   static?: Perms[]
 }>
 
-export type Rules = Record<string, Permissions>
+export type Rules = Record<string, PermissionDeclaration>
 
-export enum Perms {
-  GraphiqlLoad = 'graphiql:load',
-  IsAdmin = 'is:Admin',
-  IsLoggedIn = 'is:LoggedIn',
-  FullGameBook = 'gameBook:load',
-  GameAdmin = 'game:admin',
-  Reports = 'reports:load',
-}
+export const Perms = asEnumLike([
+  'GraphiqlLoad',
+  'IsAdmin',
+  'IsLoggedIn',
+  'FullGameBook',
+  'GameAdmin',
+  'Reports',
+] as const)
 
-export enum Roles {
-  ROLE_ADMIN = 'ROLE_ADMIN',
-  ROLE_GAME_ADMIN = 'ROLE_GAME_ADMIN',
-  ROLE_USER = 'ROLE_USER',
-  ROLE_REPORTS = 'ROLE_REPORTS',
-}
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type Perms = keyof typeof Perms
 
-const rules: Rules = {
-  [Roles.ROLE_ADMIN]: {
+const rules = {
+  ROLE_ADMIN: {
     dynamic: {
       '*': () => true,
     },
   },
-  [Roles.ROLE_GAME_ADMIN]: {
+  ROLE_GAME_ADMIN: {
     static: [Perms.FullGameBook, Perms.GameAdmin, Perms.Reports, Perms.IsLoggedIn],
   },
-  [Roles.ROLE_REPORTS]: {
+  ROLE_REPORTS: {
     static: [Perms.Reports, Perms.IsLoggedIn],
   },
-  [Roles.ROLE_USER]: {
+  ROLE_USER: {
     static: [Perms.IsLoggedIn],
   },
-}
+} satisfies Rules
+
+export const Roles = asEnumLike(keys(rules))
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type Roles = keyof typeof Roles
 
 export default rules

--- a/packages/amber/components/Auth/authUtils.ts
+++ b/packages/amber/components/Auth/authUtils.ts
@@ -1,10 +1,10 @@
 // this started off based on https://auth0.com/blog/role-based-access-control-rbac-and-react-apps/
 // changes are all my fault
 
-import type { Perms, Roles, Rules } from './PermissionRules'
+import type { PermissionDeclaration, Perms, Roles, Rules } from './PermissionRules'
 
 // note that incoming roles are defined as strings rather than Roles as they come from an external source
-// and so aren't constrained to the Roles enumeration
+// and so aren't constrained to the values in RoleType
 
 const check = (rules: Rules, role: string | null, action: Perms, roleOverride: Roles | undefined, data?: any) => {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -13,7 +13,7 @@ const check = (rules: Rules, role: string | null, action: Perms, roleOverride: R
   if (!roleToTest) {
     return false
   }
-  const permissions = rules[roleToTest] as any
+  const permissions = rules[roleToTest] as PermissionDeclaration | undefined
   if (!permissions) {
     // role is not present in the rules
     return false

--- a/packages/amber/components/Auth/useRoleOverride.tsx
+++ b/packages/amber/components/Auth/useRoleOverride.tsx
@@ -1,7 +1,7 @@
 import { atom } from 'jotai/vanilla'
 import { useAtom } from 'jotai/react'
 
-import { Roles } from './PermissionRules'
+import type { Roles } from './PermissionRules'
 
 const roleOverrideAtom = atom<Roles | undefined>(undefined)
 

--- a/packages/amber/components/Navigation/types.ts
+++ b/packages/amber/components/Navigation/types.ts
@@ -1,4 +1,4 @@
-import { Perms } from '../Auth'
+import type { Perms } from '../Auth'
 
 interface UserCondition {
   userId: number | null | undefined

--- a/packages/ui/utils/ts-utils.ts
+++ b/packages/ui/utils/ts-utils.ts
@@ -12,6 +12,12 @@ export type Merge<M, N> = Omit<M, Extract<keyof M, keyof N>> & N
 // expands object types one level deep
 export type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never
 
+type SelfProp<T extends string> = { [U in T]: U }
+
+// export convert a string array [ 'a', 'b', 'c' ] to a correctly typed object { a: 'a', b: 'b', c: 'c' }
+export const asEnumLike = <T extends readonly string[]>(v: T) =>
+  Object.fromEntries(v.map((k) => [k, k])) as Expand<SelfProp<T[number]>>
+
 // expands object types recursively
 export type ExpandRecursively<T> = T extends Record<string, unknown>
   ? T extends infer O


### PR DESCRIPTION
* typescript enums are frowned up, so I'm trying to remove usage of them slowly from the code.
* I like the idea of using the keys of the rules. One definition to maintain, and let typescript do the rest.
* being able to create correctly typed objects maintains the easy and scoped access to constants.

The meat of the change is in PermissionRules.  To be completely honest, I've not decided if this is substantially better or not, it maintains the DX of enums at low cost, and it works.  They types around how asEnumLike works can probably be tightened up, but that's a task for another day.