### PR TITLE
Add global table action to download content as CSV

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+packages/database/shared/acnw/postgraphileCache.json
+packages/database/shared/acus/postgraphileCache.json

--- a/apps/acnw/views/Memberships/membershipUtils.tsx
+++ b/apps/acnw/views/Memberships/membershipUtils.tsx
@@ -114,15 +114,13 @@ export const useEditMembership = (onClose: OnCloseHandler) => {
       .filter(notEmpty)
       .find((r) => r.id === membershipValues.hotelRoomId)
 
-    const slotDescriptions = membershipValues.slotsAttending
-      ?.split(',')
-      .map((i: string) =>
-        getSlotDescription(configuration, {
-          year: configuration.year,
-          slot: parseInt(i, 10),
-          local: configuration.virtual,
-        })
-      )
+    const slotDescriptions = membershipValues.slotsAttending?.split(',').map((i: string) =>
+      getSlotDescription(configuration, {
+        year: configuration.year,
+        slot: parseInt(i, 10),
+        local: configuration.virtual,
+      })
+    )
 
     sendEmail({
       type: 'membershipConfirmation',

--- a/apps/acus/views/Memberships/membershipUtils.tsx
+++ b/apps/acus/views/Memberships/membershipUtils.tsx
@@ -122,15 +122,13 @@ export const useEditMembership = (onClose: OnCloseHandler) => {
       .filter(notEmpty)
       .find((r) => r.id === membershipValues.hotelRoomId)
 
-    const slotDescriptions = membershipValues.slotsAttending
-      ?.split(',')
-      .map((i: string) =>
-        getSlotDescription(configuration, {
-          year: configuration.year,
-          slot: parseInt(i, 10),
-          local: configuration.virtual,
-        })
-      )
+    const slotDescriptions = membershipValues.slotsAttending?.split(',').map((i: string) =>
+      getSlotDescription(configuration, {
+        year: configuration.year,
+        slot: parseInt(i, 10),
+        local: configuration.virtual,
+      })
+    )
 
     sendEmail({
       type: 'membershipConfirmation',

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     ]
   },
   "scripts": {
+    "boot": "pnpm --filter acnw boot && pnpm --filter acus boot",
     "dev:nw": "pnpm --filter acnw dev",
     "build:nw": "pnpm --filter acnw build",
     "dev:us": "pnpm --filter acus dev",
@@ -37,6 +38,7 @@
     "lint": "pnpm -r --parallel lint",
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky install",
+    "pre-commit": "pnpm format:all && pnpm lint && pnpm tsc",
     "test": "next test",
     "tsc": "pnpm -r tsc"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,7 +8,7 @@
   "files": [],
   "private": true,
   "scripts": {
-    "lint": "eslint --cache --color '{scripts,shared,support}/**/*.{js,jsx,ts,tsx}' ./.eslintrc.js",
+    "lint": "eslint --cache --color 'src/**/*.{js,jsx,ts,tsx}' ./.eslintrc.js",
     "tsc": "tsc -p ./tsconfig.json"
   },
   "dependencies": {

--- a/packages/ui/components/Table/TableToolbar.tsx
+++ b/packages/ui/components/Table/TableToolbar.tsx
@@ -13,6 +13,7 @@ import { makeStyles } from 'tss-react/mui'
 import type { TableMouseEventHandler } from '../../types/react-table-config'
 import { ColumnHidePage } from './ColumnHidePage'
 import { FilterPage } from './FilterPage'
+import { camelToWords } from '../../utils'
 
 export const useStyles = makeStyles()((theme: Theme) => ({
   toolbar: {
@@ -139,35 +140,28 @@ export function TableToolbar<T extends Record<string, unknown>>({
     setAnchorEl(undefined)
   }
 
-  function handleFileDownloadClick() {
+  const formatColumnValue = (c: any) => {
     const textColumnEnclosure = '"'
+    return typeof c === 'string' ? `${textColumnEnclosure}${c.replaceAll('"', '""')}${textColumnEnclosure}` : c
+  }
+
+  function handleFileDownloadClick() {
     const columnSeparator = ','
     const rowSeparator = '\n'
     const timestamp = new Date().toISOString().replaceAll(/[-.]/g, '_')
-    const formatColumnValue = (c: any) => {
-      return typeof c === 'string' ? `${textColumnEnclosure}${c.replaceAll('"', '""')}${textColumnEnclosure}` : c
-    }
-    console.log(instance)
+    // console.log(instance)
     const filename = `${instance.name}-${timestamp}.csv`
     const csvHeaders = instance.visibleColumns
-      .filter((fc) => {
-        return fc.id !== '_selector'
-      })
-      .map((c) => {
-        return formatColumnValue(c.id)
-      })
+      .filter((fc) => fc.id !== '_selector')
+      .map((c) => formatColumnValue(camelToWords(c.id)))
       .join(columnSeparator)
       .concat(rowSeparator)
     const csvData = instance.rows
       .map((r) => {
         instance.prepareRow(r)
         return r.cells
-          .filter((fc) => {
-            return fc.column.id !== '_selector'
-          })
-          .map((c) => {
-            return formatColumnValue(c.value)
-          })
+          .filter((fc) => fc.column.id !== '_selector')
+          .map((c) => formatColumnValue(c.value))
           .join(columnSeparator)
       })
       .join(rowSeparator)

--- a/packages/ui/types/react-table-config.d.ts
+++ b/packages/ui/types/react-table-config.d.ts
@@ -65,6 +65,7 @@ declare module 'react-table' {
       UseResizeColumnsOptions<D>,
       UseRowSelectOptions<D>,
       UseSortByOptions<D> {
+    name?: string
     hideSelectionUi?: boolean
     defaultColumnDisableGlobalFilter?: boolean
     updateData?: (rowIndex: number, columnId: string, value: any) => void


### PR DESCRIPTION
Action added in TableToolbar. Takes the visible columns and formats them as a CSV row, then iterates through the rows, rendering each, necessary for the not-shown pages, especially if you change columns shown/hidden, and formats non-numerics as strings, enclosing in double quotes and escaping double quotes, and concatenating them as rows of CSV, separated by a newline.

It's all thrown in a Blob, a hidden link created with the url set to an object URL to the Blob, the link clicked, and then destroyed.

Resolves: #54