### PR TITLE
Fix layout of the pagination buttons

### DIFF
--- a/packages/ui/components/Table/Table.tsx
+++ b/packages/ui/components/Table/Table.tsx
@@ -388,6 +388,7 @@ export function Table<T extends Record<string, unknown>>(props: PropsWithChildre
       </TableTable>
       <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
         <TableDebugButton enabled={isDev} instance={instance} />
+        <div />
         <TablePagination<T> instance={instance} />
       </div>
       <TableDebug enabled={isDev} instance={instance} />

--- a/packages/ui/components/Table/TablePagination.tsx
+++ b/packages/ui/components/Table/TablePagination.tsx
@@ -108,6 +108,11 @@ export function TablePagination<T extends Record<string, unknown>>({
         setPageSize(Number(e.target.value))
       }}
       ActionsComponent={TablePaginationActions}
+      sx={{
+        '& p': {
+          m: 0,
+        },
+      }}
     />
   ) : null
 }


### PR DESCRIPTION
The paragraph margins much have changed at some point causing the labels to be too high.  Also the layout only worked if the debug button was being displayed. This probably went unnoticed until I swapped the button from being role based to dev build based - i.e. it was always on for me.