### PR TITLE
Ev/issue 73 download gamechoices report

### DIFF
--- a/apps/acus/pages/api/reports/gameChoicesReport.ts
+++ b/apps/acus/pages/api/reports/gameChoicesReport.ts
@@ -1,0 +1,42 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { withApiAuthRequired } from '@auth0/nextjs-auth0'
+import { configuration } from '../_constants'
+import { handleError } from '../_handleError'
+import { queryToExcelDownload } from './_queryToExcelDownload'
+
+// /api/send/membershipReport
+// auth token: required
+// body: {
+//  year?: number
+// }
+
+export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const year = req.body?.year || configuration.year
+    const query = `
+      select 
+        u.id as "userId", 
+        g.id as "gameId", 
+        m.id as "memberId", 
+        u.full_name as "Full Name", 
+        u.email as "Email",
+        gc.year as "Year", 
+        s.slot as "Slot", 
+        gc.rank as "Choice", 
+        g.name as "Game Title",
+        g.gm_names as "GM Names",
+        gc.returning_player as "Returning Player",
+        gs.message as "Message"
+      from game_choice gc 
+        join game g on gc.game_id = g.id 
+        join slot s on g.slot_id = s.id 
+        join membership m on gc.member_id = m.id 
+        join game_submission gs on m.id = gs.member_id and m.year = gs.year 
+        join "user" u on m.user_id = u.id 
+      where gc.year = ${year} 
+      order by u.id, gc.year, s.slot, gc.rank;`
+    await queryToExcelDownload(query, res)
+  } catch (err: any) {
+    handleError(err, res)
+  }
+})

--- a/apps/acus/pages/api/reports/membersWithoutGameChoicesReport.ts
+++ b/apps/acus/pages/api/reports/membersWithoutGameChoicesReport.ts
@@ -1,0 +1,33 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { withApiAuthRequired } from '@auth0/nextjs-auth0'
+import { configuration } from '../_constants'
+import { handleError } from '../_handleError'
+import { queryToExcelDownload } from './_queryToExcelDownload'
+
+// /api/send/membershipReport
+// auth token: required
+// body: {
+//  year?: number
+// }
+
+export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const year = req.body?.year || configuration.year
+    const query = `
+      select
+        u.id as "UserId",
+        m.id as "MembershipId",
+        m.year as "Year",
+        u.full_name as "FullName",
+        u.email as "Email"
+      from 
+        "membership" m
+        join "user" u on m.user_id = u.id
+        left join "game_submission" gs on m.id = gs.member_id
+      where m.year = ${year} and gs.id is null
+      order by u.full_name;`
+    await queryToExcelDownload(query, res)
+  } catch (err: any) {
+    handleError(err, res)
+  }
+})

--- a/apps/acus/pages/report-admin.tsx
+++ b/apps/acus/pages/report-admin.tsx
@@ -9,7 +9,8 @@ const reports: ReportRecord[] = [
   { name: 'GM' },
   { name: 'Game And Players' },
   { name: 'Games Scheduler' },
-  { name: 'Game Choices', perm: Perms.GameAdmin },
+  { name: 'Game Choices', perm: Perms.PlayerAdmin },
+  { name: 'Members Without Game Choices' },
 ]
 
 const Page: NextPage = () => <Reports reports={reports} />

--- a/apps/acus/pages/report-admin.tsx
+++ b/apps/acus/pages/report-admin.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import type { NextPage } from 'next'
 import { Reports, ReportRecord } from 'amber/views/Reports'
+import { Perms } from 'amber/components/Auth'
 
 const reports: ReportRecord[] = [
   { name: 'Membership' },
@@ -8,6 +9,7 @@ const reports: ReportRecord[] = [
   { name: 'GM' },
   { name: 'Game And Players' },
   { name: 'Games Scheduler' },
+  { name: 'Game Choices', perm: Perms.GameAdmin },
 ]
 
 const Page: NextPage = () => <Reports reports={reports} />

--- a/packages/amber/components/Auth/PermissionRules.ts
+++ b/packages/amber/components/Auth/PermissionRules.ts
@@ -7,7 +7,15 @@ export type PermissionDeclaration = AtLeastOne<{
 
 export type Rules = Record<string, PermissionDeclaration>
 
-export const Perms = asEnumLike(['GraphiqlLoad', 'IsAdmin', 'IsLoggedIn', 'FullGameBook', 'GameAdmin', 'Reports'])
+export const Perms = asEnumLike([
+  'GraphiqlLoad',
+  'IsAdmin',
+  'IsLoggedIn',
+  'FullGameBook',
+  'GameAdmin',
+  'PlayerAdmin',
+  'Reports',
+])
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Perms = keyof typeof Perms
@@ -20,6 +28,10 @@ const rules = {
   },
   ROLE_GAME_ADMIN: {
     static: [Perms.FullGameBook, Perms.GameAdmin, Perms.Reports, Perms.IsLoggedIn],
+  },
+  // INSERT INTO ROLE (id, authority) VALUES(6,'ROLE_PLAYER_ADMIN')
+  ROLE_PLAYER_ADMIN: {
+    static: [Perms.FullGameBook, Perms.PlayerAdmin, Perms.Reports, Perms.IsLoggedIn],
   },
   ROLE_REPORTS: {
     static: [Perms.Reports, Perms.IsLoggedIn],

--- a/packages/amber/components/LoginButton.tsx
+++ b/packages/amber/components/LoginButton.tsx
@@ -26,6 +26,7 @@ const MENU_ITEM_VIEW_AS_USER = `View as ${chosenRole}`
 const roleName = {
   'Regular User': Roles.ROLE_USER,
   'Game Admin': Roles.ROLE_GAME_ADMIN,
+  'Player Admin': Roles.ROLE_PLAYER_ADMIN,
 }
 
 interface ProfileImageProps {

--- a/packages/amber/views/Reports.tsx
+++ b/packages/amber/views/Reports.tsx
@@ -3,12 +3,14 @@ import { Page } from 'ui'
 import React, { useMemo } from 'react'
 import { AuthenticatedDownloadButton } from '../components'
 import { useConfiguration } from '../utils'
+import { HasPermission, Perms } from '../components/Auth'
 
 export type ReportRecord = {
   name: string
   url?: string
   fileLabel?: string
   virtual?: boolean
+  perm?: Perms
 }
 
 const toCamelCase = (words: string) => {
@@ -40,18 +42,20 @@ export const Reports: React.FC<ReportsProps> = ({ reports }) => {
         {filteredReports.map((r) => {
           const fileLabel = r?.fileLabel ?? toCamelCase(r.name)
           const url = r?.url ?? `${fileLabel}Report`
-          // console.log({ name: r.name, url })
-
-          return (
-            <ListItem key={url}>
-              <AuthenticatedDownloadButton
-                url={`/api/reports/${url}`}
-                filename={`${abbr}${configuration.year}-${fileLabel}-${timestamp}.xlsx`}
-              >
-                Download {r.name} Report
-              </AuthenticatedDownloadButton>
-            </ListItem>
-          )
+          if (r.perm === undefined || HasPermission(r.perm)) {
+            return (
+              <ListItem key={url}>
+                <AuthenticatedDownloadButton
+                  url={`/api/reports/${url}`}
+                  filename={`${abbr}${configuration.year}-${fileLabel}-${timestamp}.xlsx`}
+                >
+                  Download {r.name} Report
+                </AuthenticatedDownloadButton>
+              </ListItem>
+            )
+          } else {
+            return null
+          }
         })}
       </List>
     </Page>

--- a/queries/list_gamechoices.sql
+++ b/queries/list_gamechoices.sql
@@ -1,0 +1,7 @@
+select u.id as "user.id", s.id as "slot.id", g.id as "game.id", m.id as "member.id", u.full_name, u.email, s.slot, g.name, g.gm_names, gc.rank, gc.year, gc.returning_player from game_choice gc 
+	join game g on gc.game_id = g.id 
+	join slot s on g.slot_id = s.id 
+	join membership m on gc.member_id = m.id 
+	join "user" u on m.user_id = u.id 
+where gc.year = 2023
+order by u.id, gc.year, s.slot, gc.rank

--- a/queries/list_gamechoices_slotcount.sql
+++ b/queries/list_gamechoices_slotcount.sql
@@ -1,0 +1,9 @@
+select u.id as "user.id", u.full_name, u.email, count(distinct s.id) as "slot_choices"
+from membership m
+    left join game_choice gc on gc.member_id = m.id
+	left join game g on gc.game_id = g.id 
+	left join slot s on g.slot_id = s.id 
+	left join "user" u on m.user_id = u.id 
+where m.year = 2023
+group by u.id, u.full_name, u.email
+order by full_name


### PR DESCRIPTION
Tested locally against ACUS and ACNW.

Report and report config not ported to ACNW.

Changes as is for ACUS require a role 'ROLE_PLAYER_ADMIN' :

INSERT INTO ROLE (id, authority) VALUES(6,'ROLE_PLAYER_ADMIN')

Other changes allow an optional perm on the ReportRecord in report-admin.tsx.

Reports.tsx has some severe TypeScript stupidity that's my stupidity as adding the condition on line 45 as an additional compound test to the filtering on line 35 (where it belonged), or even as a tertiary operator within the return just did not like me. This works. I'm going to call it good and take a nap. (also, obviously, feel free to fix it). I'll look at it again after pulling members, games, and game choices and get them in the format my scheduling spreadsheet uses.

Cheers