### PR TITLE
ACUS: Fix selecting No Game / Any Game in games report

### DIFF
--- a/apps/acus/pages/api/reports/gamesForPlayerSchedulerReport.ts
+++ b/apps/acus/pages/api/reports/gamesForPlayerSchedulerReport.ts
@@ -29,8 +29,9 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
         g.player_min as "Min",
         g.player_max as "Max",
         g.returning_players as "Returning Players"
-      from game g join "user" u on g.author_id = u.id
-      where g.year = ${year} and g.slot_id >=1 and g.slot_id <= 8;`
+      from game g left join "user" u on g.author_id = u.id
+      where (g.year = ${year} and g.slot_id >=1 and g.slot_id <=8) or (g.id >= 596 and g.id <= 604);`
+
     await queryToExcelDownload(query, res)
   } catch (err: any) {
     handleError(err, res)


### PR DESCRIPTION
The No Game / Any Game are re-used across years and were filtered out as they didn't match the year and don't have an author so the join dropped them.

Changed to a left join on the author to user, and an or'ed clause to select the special games by their id (they are static in the games table).

Resolves: #86