### PR TITLE
ACUS: Include special games and format returning player in game choices report for player scheduler

### DIFF
--- a/apps/acus/pages/api/reports/gameChoicesForPlayerSchedulerReport.ts
+++ b/apps/acus/pages/api/reports/gameChoicesForPlayerSchedulerReport.ts
@@ -33,7 +33,7 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
         join membership m on gc.member_id = m.id 
         join game_submission gs on m.id = gs.member_id and m.year = gs.year 
         join "user" u on m.user_id = u.id 
-      where gc.year = ${year} and gc.game_id in (select g.id from "game" g where g.year = 2023 or (g.id >= 596 and g.id <= 604))
+      where gc.year = ${year} and gc.game_id in (select g.id from "game" g where g.year = ${year} or (g.id >= 596 and g.id <= 604))
       order by u.id, gc.year, s.slot, gc.rank;`
     await queryToExcelDownload(query, res)
   } catch (err: any) {

--- a/apps/acus/pages/api/reports/gameChoicesForPlayerSchedulerReport.ts
+++ b/apps/acus/pages/api/reports/gameChoicesForPlayerSchedulerReport.ts
@@ -25,15 +25,15 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
         gc.rank as "Choice", 
         g.name as "Game Title",
         g.gm_names as "GM Names",
-        gc.returning_player as "Returning Player",
+        (case when gc.returning_player then 'Yes' else 'No' end) as "Returning Player",
         gs.message as "Message"
       from game_choice gc 
         join game g on gc.game_id = g.id 
-        join slot s on g.slot_id = s.id 
+        join slot s on gc.slot_id = s.id 
         join membership m on gc.member_id = m.id 
         join game_submission gs on m.id = gs.member_id and m.year = gs.year 
         join "user" u on m.user_id = u.id 
-      where gc.year = ${year} 
+      where gc.year = ${year} and gc.game_id in (select g.id from "game" g where g.year = 2023 or (g.id >= 596 and g.id <= 604))
       order by u.id, gc.year, s.slot, gc.rank;`
     await queryToExcelDownload(query, res)
   } catch (err: any) {


### PR DESCRIPTION
The report joined from game to slot and the special game Any Game is in no specific slot so dropped out.

Special games also have no year - they are reused - so are included by special magic ids.

The returning player was formatted to Yes/No for space reasons in the scheduling spreadsheet.

Resolves: #89