### PR TITLE
Fix bug where editing a game after game assignments are made removes the GM GMing their game entries

### DIFF
--- a/packages/amber/views/Games/gameHooks.tsx
+++ b/packages/amber/views/Games/gameHooks.tsx
@@ -71,7 +71,7 @@ export const useUpdateGameAssignment = () => {
         const oldAssignments = gameAssignmentData.gameAssignments?.nodes
           .filter(notEmpty)
           .filter((ga) => ga.gameId === gameId)
-          .filter((ga) => ga.gm !== 0) as GameAssignment[]
+          .filter((ga) => ga.gm < 0) as GameAssignment[]
 
         const oldIds = oldAssignments.map((o) => o.memberId).sort((a, b) => a - b)
         const newIds = gmMemberships.map((m) => m.id).sort((a, b) => a - b)


### PR DESCRIPTION
Game Assignments have negative numbers for GMs for the game book, and positive numbers for GMs GMing their game, and 0 for players in the game.

This game hook runs on editing a game, and tries to match GM names to user names.

It removed all entries not equal to zero, but only regenerates the GM entries, i.e. with a negative number.

However if you do this after game assignments are created, it removes the entry for the GM GMing their own game, and it disappears from their schedule.

Changed the test to only remove the negative "GM" entries as those are re-created.

Tested locally on ACUS with a single GM game and with two GM game where one of the GM's names does not match their user name entries.

Resolves: #106