### PR TITLE
Ev/issue 108 fix game choices export for games moved to slot 0

### DIFF
--- a/apps/acus/pages/api/reports/gameAndPlayersWithNoGameReport.ts
+++ b/apps/acus/pages/api/reports/gameAndPlayersWithNoGameReport.ts
@@ -26,8 +26,8 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
           join game_assignment ga on m.id = ga.member_id
           join game g on g.id = ga.game_id
           join "user" u on m.user_id = u.id
-          where m.year = ${year} and g.name != 'No Game' and ga.gm >= 0
-          order by g.slot_id, g.name, ga.gm desc, u.full_name
+          where m.year = ${year} and ga.gm >= 0
+          order by "Slot", "Game", ga.gm desc, "Member"
         `
     await queryToExcelDownload(query, res)
   } catch (err: any) {

--- a/apps/acus/pages/api/reports/gameChoicesForPlayerSchedulerReport.ts
+++ b/apps/acus/pages/api/reports/gameChoicesForPlayerSchedulerReport.ts
@@ -21,7 +21,7 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
         u.full_name as "Full Name", 
         u.email as "Email",
         gc.year as "Year", 
-        s.slot as "Slot", 
+        gc.slot_id as "Slot", 
         gc.rank as "Choice", 
         g.name as "Game Title",
         g.gm_names as "GM Names",
@@ -29,12 +29,11 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
         gs.message as "Message"
       from game_choice gc 
         join game g on gc.game_id = g.id 
-        join slot s on gc.slot_id = s.id 
         join membership m on gc.member_id = m.id 
         join game_submission gs on m.id = gs.member_id and m.year = gs.year 
         join "user" u on m.user_id = u.id 
       where gc.year = ${year} and gc.game_id in (select g.id from "game" g where g.year = ${year} or (g.id >= 596 and g.id <= 604))
-      order by u.id, gc.year, s.slot, gc.rank;`
+      order by u.full_name, gc.year, gc.slot_id, gc.rank;`
     await queryToExcelDownload(query, res)
   } catch (err: any) {
     handleError(err, res)

--- a/apps/acus/pages/api/reports/gameChoicesForPlayerSchedulerReport.ts
+++ b/apps/acus/pages/api/reports/gameChoicesForPlayerSchedulerReport.ts
@@ -32,7 +32,7 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
         join membership m on gc.member_id = m.id 
         join game_submission gs on m.id = gs.member_id and m.year = gs.year 
         join "user" u on m.user_id = u.id 
-      where gc.year = ${year} and gc.game_id in (select g.id from "game" g where g.year = ${year} or (g.id >= 596 and g.id <= 604))
+      where gc.year = ${year} and gc.game_id in (select g.id from "game" g where g.year = ${year} or (g.author_id is null))
       order by u.full_name, gc.year, gc.slot_id, gc.rank;`
     await queryToExcelDownload(query, res)
   } catch (err: any) {

--- a/apps/acus/pages/api/reports/gameReport.ts
+++ b/apps/acus/pages/api/reports/gameReport.ts
@@ -36,7 +36,8 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
             g.late_finish as "Late Finish",
             g.message as "Message"
             from game g join "user" u  on g.author_id = u.id
-          where g.year = ${year}`
+          where g.year = ${year}
+          order by g.year, g.slot_id, g.name`
     await queryToExcelDownload(query, res)
   } catch (err: any) {
     handleError(err, res)

--- a/apps/acus/pages/api/reports/gamesForPlayerSchedulerReport.ts
+++ b/apps/acus/pages/api/reports/gamesForPlayerSchedulerReport.ts
@@ -31,7 +31,7 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
         g.returning_players as "Returning Players"
       from game g
       left join "user" u on g.author_id = u.id
-      where (g.year = ${year} and g.slot_id >=1 and g.slot_id <=8) or (g.id >= 596 and g.id <= 604)
+      where (g.year = ${year} and g.slot_id >=1 and g.slot_id <=8) or (g.author_id is null)
       order by g.slot_id, g.year desc, g.name;`
 
     await queryToExcelDownload(query, res)

--- a/apps/acus/pages/api/reports/gamesForPlayerSchedulerReport.ts
+++ b/apps/acus/pages/api/reports/gamesForPlayerSchedulerReport.ts
@@ -29,8 +29,10 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
         g.player_min as "Min",
         g.player_max as "Max",
         g.returning_players as "Returning Players"
-      from game g left join "user" u on g.author_id = u.id
-      where (g.year = ${year} and g.slot_id >=1 and g.slot_id <=8) or (g.id >= 596 and g.id <= 604);`
+      from game g
+      left join "user" u on g.author_id = u.id
+      where (g.year = ${year} and g.slot_id >=1 and g.slot_id <=8) or (g.id >= 596 and g.id <= 604)
+      order by g.slot_id, g.year desc, g.name;`
 
     await queryToExcelDownload(query, res)
   } catch (err: any) {

--- a/apps/acus/pages/api/reports/gamesSchedulerReport.ts
+++ b/apps/acus/pages/api/reports/gamesSchedulerReport.ts
@@ -28,8 +28,10 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
             g.slot_id as "Slot",
             g.slot_preference as "Slot Preference",
             g.message as "Message"
-            from game g join "user" u  on g.author_id = u.id
-          where g.year = ${year}`
+            from game g 
+            join "user" u  on g.author_id = u.id
+          where g.year = ${year}
+          order by g.year, g.slot_id, g.name`
     await queryToExcelDownload(query, res)
   } catch (err: any) {
     handleError(err, res)

--- a/apps/acus/pages/api/reports/membersForPlayerSchedulerReport.ts
+++ b/apps/acus/pages/api/reports/membersForPlayerSchedulerReport.ts
@@ -41,7 +41,8 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
         from membership m 
         group by m.user_id
         ) mc on u.id = mc.user_id
-    where m.year = ${year};`
+    where m.year = ${year}
+    order by u.full_name;`
     await queryToExcelDownload(query, res)
   } catch (err: any) {
     handleError(err, res)

--- a/apps/acus/pages/api/reports/membershipReport.ts
+++ b/apps/acus/pages/api/reports/membershipReport.ts
@@ -31,7 +31,8 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
                   join game_assignment ga on ga.member_id = m.id
                 where m.year = ${year} and ga.gm < 0
           ) gm on gm.id = m.id
-        where m.year = ${year}`
+        where m.year = ${year}
+        order by u.full_name`
       : `
         select 
           m.id as "Member Id",
@@ -57,7 +58,8 @@ export default withApiAuthRequired(async (req: NextApiRequest, res: NextApiRespo
             from membership m 
             group by m.user_id
           ) mc on u.id = mc.user_id
-        where m.year = ${year};
+        where m.year = ${year}
+        order by u.full_name;
         `
     await queryToExcelDownload(query, res)
   } catch (err: any) {


### PR DESCRIPTION
Fix reports: sort, not use slot, filter on author_id

pages/api/reports/gameAndPlayersReport.ts
  fix sort
pages/api/reports/gameChoicesForPlayerSchedulerReport.ts
  remove join to table slot
  change filtering for special games from id to author_id IS NULL
pages/api/reports/gameReport.ts
  add sort
pages/api/reports/gamesForPlayerSchedulerReport.ts
  add sort
  change filtering for special games from id to author_id IS NULL
pages/api/reports/gamesSchedulerReport.ts
  add sort
pages/api/reports/membersForPlayerSchedulerReport.ts
  add sort
pages/api/reports/membershipReport.ts
  add sort

Resolves: #108, #110, #109