### PR TITLE
Add perm-flag value of GameAdmin to flags

### DIFF
--- a/packages/amber/utils/settings.tsx
+++ b/packages/amber/utils/settings.tsx
@@ -13,13 +13,12 @@ export enum SettingValue {
   GameAdmin = 'GameAdmin',
   GM = 'GM',
   Member = 'Member',
-  Everyone = 'Everyone',
   Yes = 'Yes',
 }
 
 const asSettingValue = (s: string): SettingValue => SettingValue[s as keyof typeof SettingValue]
 
-export const permissionGateValues = ['No', 'Admin', 'GameAdmin', 'GM', 'Member', 'Everyone', 'Yes']
+export const permissionGateValues = ['No', 'Admin', 'GameAdmin', 'GM', 'Member', 'Yes']
 
 export const useSettings = () => {
   const isGm = useIsGm()

--- a/packages/amber/utils/settings.tsx
+++ b/packages/amber/utils/settings.tsx
@@ -79,7 +79,6 @@ export const useSettings = () => {
           return isAdmin || isGameAdmin || isGm
         case SettingValue.Member:
           return isAdmin || isMember
-        case SettingValue.Everyone:
         case SettingValue.Yes:
           return true
         case null:

--- a/packages/amber/utils/settings.tsx
+++ b/packages/amber/utils/settings.tsx
@@ -10,6 +10,7 @@ import { Perms, useAuth } from '../components/Auth'
 export enum SettingValue {
   No = 'No',
   Admin = 'Admin',
+  GameAdmin = 'GameAdmin',
   GM = 'GM',
   Member = 'Member',
   Everyone = 'Everyone',
@@ -18,13 +19,14 @@ export enum SettingValue {
 
 const asSettingValue = (s: string): SettingValue => SettingValue[s as keyof typeof SettingValue]
 
-export const permissionGateValues = ['No', 'Admin', 'GM', 'Member', 'Everyone', 'Yes']
+export const permissionGateValues = ['No', 'Admin', 'GameAdmin', 'GM', 'Member', 'Everyone', 'Yes']
 
 export const useSettings = () => {
   const isGm = useIsGm()
   const isMember = useIsMember()
   const { hasPermissions } = useAuth()
   const isAdmin = hasPermissions(Perms.IsAdmin)
+  const isGameAdmin = hasPermissions(Perms.GameAdmin)
   const { isLoading, error, data } = useGraphQL(GetSettingsDocument)
 
   const getSettingString = useCallback(
@@ -72,8 +74,10 @@ export const useSettings = () => {
       switch (s) {
         case SettingValue.Admin:
           return isAdmin
+        case SettingValue.GameAdmin:
+          return isAdmin || isGameAdmin
         case SettingValue.GM:
-          return isAdmin || isGm
+          return isAdmin || isGameAdmin || isGm
         case SettingValue.Member:
           return isAdmin || isMember
         case SettingValue.Everyone:


### PR DESCRIPTION
We want to be able for the game admin to preview the gamebook but there is no perm-flag setting value for it, so we added that, more or less as a hierarchy of Admin > GameAdmin > GM where each level includes the ones above.

Resolves: #59