### PR TITLE
Add a better fix to skip the "no game" games in the calendar

### DIFF
--- a/packages/amber/views/Schedule/SchedulePage.tsx
+++ b/packages/amber/views/Schedule/SchedulePage.tsx
@@ -126,10 +126,11 @@ const getIcalUrl = (configuration: Configuration, schedule: GameAssignmentNode[]
     schedule
       .map((gas) => {
         const { game } = gas
-        if (!game || game.id < 8) return null
+        // skip "no game" games
+        if (!game || game.year === 0) return null
 
         const slotId = game.slotId!
-        const [start, end] = getSlotTimes(configuration, game.year || configuration.year)[slotId - 1]
+        const [start, end] = getSlotTimes(configuration, game.year)[slotId - 1]
         const gameUrl = `${window.location.origin}/game-book/${game.year}/${slotId}#${game.id}`
         const { gms, players } = getGmsAndPlayers(game)
         const gmNames = gms.map((p) => `${p.fullName} (${p.email})`)


### PR DESCRIPTION
The "no game" games are shared across all years, so we need to filter them out.